### PR TITLE
Fix: JPA query문 수정

### DIFF
--- a/memo/src/main/kotlin/com/mistar/memo/domain/model/repository/MemoRepository.kt
+++ b/memo/src/main/kotlin/com/mistar/memo/domain/model/repository/MemoRepository.kt
@@ -1,11 +1,19 @@
 package com.mistar.memo.domain.model.repository
 
 import com.mistar.memo.domain.model.entity.Memo
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
+import java.util.*
 
 @Repository
 interface MemoRepository : JpaRepository<Memo, Int> {
+    fun findAllByIsDeletedIsFalseAndIsPublicIsTrue(): List<Memo>
+
+    fun findAllByIsDeletedIsFalseAndIsPublicIsTrue(page: Pageable): List<Memo>
+
+    fun findByIdAndIsDeletedIsFalseAndIsPublicIsTrue(memoId: Int): Optional<Memo>
+
     fun findAllByDeletedAtBeforeAndIsDeletedIsTrue(now: LocalDateTime): List<Memo>
 }

--- a/memo/src/main/kotlin/com/mistar/memo/domain/model/repository/TagRepository.kt
+++ b/memo/src/main/kotlin/com/mistar/memo/domain/model/repository/TagRepository.kt
@@ -2,10 +2,18 @@ package com.mistar.memo.domain.model.repository
 
 import com.mistar.memo.domain.model.entity.Tag
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface TagRepository : JpaRepository<Tag, Int> {
+    @Query(
+        """
+            select t from Tag t
+            inner join Memo m on m.id = t.memoId
+            where m.isDeleted = false and m.isPublic = true
+        """
+    )
     fun findByContentContaining(content: String): List<Tag>
 
     fun existsByMemoIdAndContent(memoId: Int, content: String): Boolean

--- a/memo/src/main/kotlin/com/mistar/memo/domain/service/MemoService.kt
+++ b/memo/src/main/kotlin/com/mistar/memo/domain/service/MemoService.kt
@@ -48,16 +48,16 @@ class MemoService(
     fun selectAllMemos(page: Int): List<Memo> {
         if (page < 1)
             throw InvalidPageException()
-        val memoCnt = memoRepository.findAll().size
+        val memoCnt = memoRepository.findAllByIsDeletedIsFalseAndIsPublicIsTrue().size
         if (memoCnt < (page - 1) * 10)
             throw PageOutOfBoundsException()
 
         val requestedPage = Page(page - 1, defaultPageSize)
-        return memoRepository.findAll(requestedPage).toList()
+        return memoRepository.findAllByIsDeletedIsFalseAndIsPublicIsTrue(requestedPage).toList()
     }
 
     fun selectMemosById(memoId: Int): List<Memo> {
-        val memo = memoRepository.findById(memoId).orElseThrow {
+        val memo = memoRepository.findByIdAndIsDeletedIsFalseAndIsPublicIsTrue(memoId).orElseThrow {
             MemoNotFoundException()
         }
         return listOf(memo)


### PR DESCRIPTION
Scheduling을 통한 Memo 삭제가 이루어지면서
Memo Entity의 @Where 절이 삭제됨
이에 따라 Memo를 조회하는 모든 JPA 쿼리문 조건에 isDeleted=true and isPublic=true이 추가됨